### PR TITLE
[✨FEATURE] 마이드림 할일목록(D1-1) UI 구현 

### DIFF
--- a/src/common/CheckList.tsx
+++ b/src/common/CheckList.tsx
@@ -1,8 +1,15 @@
 import { useState, useEffect } from 'react';
 import Check from '@assets/icons/check.svg?react';
+import MemoIcon from '@assets/icons/memo.svg?react';
+import ReWriteIcon from '@assets/icons/edit-write.svg?react';
+import TrashIcon from '@assets/icons/delete-trash.svg?react';
+import ToastModal from './modal/ToastModal';
+import Info from '@assets/icons/info.svg?react';
+
+type ChecklistItem = string | { text: string; hasMemo?: boolean };
 
 interface CheckListProps {
-  lists: string[];
+  lists: ChecklistItem[];
   defaultCheckedList?: boolean[];
   className?: string;
   onChange?: (checkedList: boolean[]) => void;
@@ -14,9 +21,20 @@ const CheckList = ({
   className = '',
   onChange,
 }: CheckListProps) => {
-  const [checkedList, setCheckedList] = useState<boolean[]>(
-    defaultCheckedList ?? new Array(lists.length).fill(false)
+  const normalized = lists.map((item) =>
+    typeof item === 'string' ? { text: item } : item
   );
+
+  const [listItems, setListItems] = useState(normalized);
+  const [checkedList, setCheckedList] = useState<boolean[]>(
+    defaultCheckedList ?? new Array(normalized.length).fill(false)
+  );
+  const [showToast, setShowToast] = useState<boolean>(false);
+  const [lastDeleted, setLastDeleted] = useState<{
+    item: { text: string; hasMemo?: boolean };
+    index: number;
+    checked: boolean;
+  } | null>(null);
 
   useEffect(() => {
     if (onChange) {
@@ -30,33 +48,109 @@ const CheckList = ({
     setCheckedList(newList);
   };
 
+  const handleDelete = (index: number) => {
+    const deletedItem = listItems[index];
+    const deletedChecked = checkedList[index];
+
+    const newItems = [...listItems];
+    newItems.splice(index, 1);
+    setListItems(newItems);
+
+    const newChecked = [...checkedList];
+    newChecked.splice(index, 1);
+    setCheckedList(newChecked);
+
+    setLastDeleted({ item: deletedItem, index, checked: deletedChecked });
+    setShowToast(true);
+
+    setTimeout(() => {
+      setShowToast(false);
+      setLastDeleted(null);
+    }, 2500);
+  };
+
+  const handleUndoDelete = () => {
+    if (!lastDeleted) return;
+
+    const newItems = [...listItems];
+    newItems.splice(lastDeleted.index, 0, lastDeleted.item);
+    setListItems(newItems);
+
+    const newChecked = [...checkedList];
+    newChecked.splice(lastDeleted.index, 0, lastDeleted.checked);
+    setCheckedList(newChecked);
+
+    setShowToast(false);
+    setLastDeleted(null);
+  };
+
   return (
     <div className={className}>
-      {lists.map((text, index) => {
+      {listItems.map(({ text, hasMemo }, index) => {
         const done = checkedList[index];
         return (
-          <div key={index} className="flex w-full flex-row items-center gap-2">
-            <div
-              className={`flex h-[30px] w-[30px] shrink-0 items-center justify-center rounded-lg border ${
-                done
-                  ? 'border-purple-300 bg-purple-150 text-purple-600'
-                  : 'border-gray-300 bg-gray-100 text-transparent'
-              } cursor-pointer transition-colors duration-150`}
-              onClick={() => toggleCheck(index)}
-            >
-              {done && <Check className="h-[19px] w-[19px]" />}
+          <div
+            key={index}
+            className="flex w-full items-center justify-between gap-2"
+          >
+            <div className="flex items-center gap-2">
+              <div
+                className={`flex h-[30px] w-[30px] shrink-0 items-center justify-center rounded-lg border ${
+                  done
+                    ? 'border-purple-300 bg-purple-150 text-purple-600'
+                    : 'border-gray-300 bg-gray-100 text-transparent'
+                } cursor-pointer transition-colors duration-150`}
+                onClick={() => toggleCheck(index)}
+              >
+                {done && <Check className="h-[19px] w-[19px]" />}
+              </div>
+
+              <span
+                className={`truncate font-B02-M ${
+                  done ? 'text-gray-500' : 'text-gray-800'
+                }`}
+              >
+                {text}
+              </span>
             </div>
 
-            <span
-              className={`truncate font-B02-M ${
-                done ? 'text-gray-500' : 'text-gray-800'
-              }`}
-            >
-              {text}
-            </span>
+            {hasMemo && (
+              <div className="group ml-auto flex min-w-fit items-center gap-[5px]">
+                <button className="flex items-center gap-[6px] rounded-[10px] bg-purple-100 px-3 py-2 text-purple-500 font-B03-SB">
+                  <MemoIcon className="h-[18px] w-[18px] text-purple-500" />
+                  메모
+                </button>
+
+                <div className="flex flex-row gap-[5px] opacity-0 transition-opacity duration-200 group-hover:opacity-100">
+                  <button className="flex items-center gap-[6px] rounded-[10px] bg-gray-100 px-3 py-2 text-gray-500 font-B03-SB">
+                    <ReWriteIcon className="h-[18px] w-[18px]" />
+                    편집
+                  </button>
+                  <button
+                    onClick={() => handleDelete(index)}
+                    className="flex items-center gap-[6px] rounded-[10px] bg-gray-100 px-3 py-2 text-gray-500 font-B03-SB"
+                  >
+                    <TrashIcon className="h-[18px] w-[18px]" />
+                    삭제
+                  </button>
+                </div>
+              </div>
+            )}
           </div>
         );
       })}
+
+      {showToast && (
+        <div className="fixed top-[130px] z-50 items-center">
+          <ToastModal
+            icon={<Info className="h-6 w-6 text-white" />}
+            text="할일목록 1개가 삭제되었습니다"
+            undoText="삭제취소"
+            onUndo={handleUndoDelete}
+            width="w-[469px]"
+          />
+        </div>
+      )}
     </div>
   );
 };

--- a/src/common/FloatingButton.tsx
+++ b/src/common/FloatingButton.tsx
@@ -56,7 +56,7 @@ const FloatingButton = () => {
       )}
 
       {showToast && (
-        <div className="fixed right-[564px] top-[100px] z-50">
+        <div className="fixed left-1/2 top-[120px] z-50 -translate-x-1/2 -translate-y-1/2 transform">
           <ToastModal
             icon={<Info className="text-white" />}
             text="할일 목록이 추가되었습니다"

--- a/src/common/Header.tsx
+++ b/src/common/Header.tsx
@@ -24,7 +24,7 @@ const NavItems = [
   //마이드림
   {
     label: '나의 할일',
-    path: '/mytodo',
+    path: '/mytodo/list',
     match: (pathname: string) => pathname.startsWith('/mytodo'),
   },
 ];

--- a/src/common/modal/ToastModal.tsx
+++ b/src/common/modal/ToastModal.tsx
@@ -3,13 +3,37 @@ import { ReactNode } from 'react';
 interface ToastProps {
   text: string | ReactNode;
   icon?: ReactNode;
+  undoText?: string;
+  onUndo?: () => void;
+  width?: string;
 }
 
-const ToastModal = ({ text, icon }: ToastProps) => {
+const ToastModal = ({
+  text,
+  icon,
+  undoText,
+  onUndo,
+  width = 'min-w-[320px]',
+}: ToastProps) => {
   return (
-    <div className="flex items-center justify-center gap-[10px] rounded-full bg-gray-800 px-[30px] py-5 shadow-shadow4">
-      {icon && <div>{icon}</div>}
-      <div className="text-white font-T05-SB">{text}</div>
+    <div
+      className={`flex items-center justify-between rounded-full bg-gray-800 px-[24px] py-[14px] shadow-shadow4 ${width}`}
+    >
+      <div className="flex items-center gap-[10px]">
+        {icon && <div className="text-white">{icon}</div>}
+        <div className="whitespace-nowrap text-sm text-white font-T05-SB">
+          {text}
+        </div>
+      </div>
+
+      {onUndo && (
+        <button
+          onClick={onUndo}
+          className="text-gray-300 underline underline-offset-1 transition font-T05-SB hover:text-white"
+        >
+          {undoText || ''}
+        </button>
+      )}
     </div>
   );
 };

--- a/src/outlet/SidebarLayout.tsx
+++ b/src/outlet/SidebarLayout.tsx
@@ -1,3 +1,4 @@
+import Footer from '@common/Footer';
 import { ReactNode } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 
@@ -7,10 +8,11 @@ interface SidebarLayoutProps {
 
 const SidebarLayout = ({ children }: SidebarLayoutProps) => {
   const { pathname } = useLocation();
+  const showFooter = pathname === '/mytodo/list';
 
   return (
-    <div className="flex min-h-screen">
-      <aside className="fixed left-0 h-screen w-[200px] bg-white shadow-sm">
+    <div className="flex">
+      <aside className="fixed left-0 h-screen w-[200px] bg-white">
         <nav className="py-10">
           <ul className="flex flex-col gap-2 px-4">
             <li>
@@ -42,7 +44,10 @@ const SidebarLayout = ({ children }: SidebarLayoutProps) => {
         </nav>
       </aside>
 
-      <main className="ml-[200px] flex-1 bg-gray-50 p-6">{children}</main>
+      <main className="ml-[200px] flex min-h-screen w-full flex-col bg-gray-50">
+        <div className="flex-1">{children}</div>
+        {showFooter && <Footer />}
+      </main>
     </div>
   );
 };

--- a/src/outlet/SidebarLayout.tsx
+++ b/src/outlet/SidebarLayout.tsx
@@ -17,7 +17,8 @@ const SidebarLayout = ({ children }: SidebarLayoutProps) => {
               <Link
                 to="/mytodo/list"
                 className={`block w-full rounded-2xl px-4 py-3 text-left font-B01-B ${
-                  pathname.includes('/mytodo/list')
+                  pathname.includes('/mytodo/list') ||
+                  pathname.includes('/mytodo/add')
                     ? 'bg-purple-100 text-purple-500'
                     : 'text-gray-400 hover:text-purple-500'
                 }`}

--- a/src/pages/jobDetail/components/ProfileCard.tsx
+++ b/src/pages/jobDetail/components/ProfileCard.tsx
@@ -2,6 +2,7 @@ import Checker from '@assets/images/checker.png';
 import Button from '@common/Button';
 import CheckList from '@common/CheckList';
 import Divider from '@common/Divider';
+import { useNavigate, useParams } from 'react-router-dom';
 
 const todotext = [
   '아롱이 병원에ㅇㅇㅇ 들렀을 때, 늘 친절하신 간호 선생님께 취업 경로 살짝 여쭤보기',
@@ -9,6 +10,8 @@ const todotext = [
 ];
 
 const ProfileCard = () => {
+  const navigate = useNavigate();
+  const { jobId } = useParams<{ jobId: string }>();
   return (
     <div className="mt-[66px] flex h-[752px] w-[444px] flex-col items-start rounded-[30px] bg-white p-[30px]">
       <div className="text-black font-T03-B">
@@ -88,6 +91,7 @@ const ProfileCard = () => {
         color="secondary"
         type="button"
         className="mt-10 flex w-full items-center justify-center rounded-2xl border border-purple-500 py-4 font-T05-SB hover:bg-purple-150"
+        onClick={() => navigate(`/otherslist/${jobId}`)}
       />
     </div>
   );

--- a/src/pages/myTodo/components/todo/Todo.tsx
+++ b/src/pages/myTodo/components/todo/Todo.tsx
@@ -1,0 +1,47 @@
+import BackIcon from '@assets/icons/back.svg?react';
+import Eye from '@assets/icons/show_pw.svg?react';
+import CheckList from '@common/CheckList';
+import Divider from '@common/Divider';
+import Plus from '@assets/icons/plus.svg?react';
+
+const list = [
+  { text: '고용24에서 인근 요양보호사 과정 검색하기', hasMemo: true },
+  { text: '지역 교육기관 전화로 일정 문의하기' },
+  { text: '지원서 작성용 사진 준비하기', hasMemo: true },
+  { text: '건강검진 일정 잡기' },
+  { text: '인터넷으로 접수하기', hasMemo: true },
+  { text: '제출 서류 준비 완료 확인' },
+];
+
+const Todo = () => {
+  return (
+    <div className="mt-10 flex flex-col px-[120px]">
+      <div className="flex flex-row justify-between">
+        <div className="flex flex-row items-center gap-[21px]">
+          <div className="text-gray-900 font-T02-B">요양보호사</div>
+          <BackIcon className="-rotate-90" />
+        </div>
+
+        <div className="flex flex-row items-center gap-[6px]">
+          <Eye />
+          <div className="text-gray-500 font-B03-M"> 조회수 NNNN </div>
+        </div>
+      </div>
+
+      <div className="mt-[30px] flex w-full flex-col items-start rounded-[30px] border border-gray-300 bg-white p-[30px]">
+        <div className="text-black font-T04-SB"> 할 일 목록</div>
+        <Divider className="mb-4 mt-4" />
+        <CheckList
+          lists={list}
+          className="flex w-full flex-col items-center gap-8 pt-4"
+        />
+        <button className="mt-[26px] flex w-full items-center justify-center gap-[6px] rounded-2xl bg-purple-500 py-[14px] text-white font-T05-SB hover:bg-purple-600">
+          <Plus className="h-6 w-6" />
+          추가하기
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default Todo;

--- a/src/pages/myTodo/components/todo/Todo.tsx
+++ b/src/pages/myTodo/components/todo/Todo.tsx
@@ -1,8 +1,10 @@
+import { useState } from 'react';
 import BackIcon from '@assets/icons/back.svg?react';
 import Eye from '@assets/icons/show_pw.svg?react';
 import CheckList from '@common/CheckList';
 import Divider from '@common/Divider';
 import Plus from '@assets/icons/plus.svg?react';
+import { useNavigate } from 'react-router-dom';
 
 const list = [
   { text: '고용24에서 인근 요양보호사 과정 검색하기', hasMemo: true },
@@ -13,13 +15,55 @@ const list = [
   { text: '제출 서류 준비 완료 확인' },
 ];
 
+const jobOptions = ['간호 조무사', '바리스타', '요양보호사'];
+
 const Todo = () => {
+  const navigate = useNavigate();
+  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+  const [selectedJob, setSelectedJob] = useState('요양보호사');
+
+  const toggleDropdown = () => {
+    setIsDropdownOpen((prev) => !prev);
+  };
+
+  const handleSelect = (job: string) => {
+    setSelectedJob(job);
+    setIsDropdownOpen(false);
+  };
+
   return (
     <div className="mt-10 flex flex-col px-[120px]">
       <div className="flex flex-row justify-between">
-        <div className="flex flex-row items-center gap-[21px]">
-          <div className="text-gray-900 font-T02-B">요양보호사</div>
-          <BackIcon className="-rotate-90" />
+        <div className="relative flex flex-col items-start">
+          <div
+            className="flex cursor-pointer flex-row items-center gap-[10px]"
+            onClick={toggleDropdown}
+          >
+            <div className="text-gray-900 font-T02-B">{selectedJob}</div>
+            <BackIcon
+              className={`transition-transform duration-200 ${
+                isDropdownOpen ? '-rotate-90' : '-rotate-90'
+              }`}
+            />
+          </div>
+
+          {isDropdownOpen && (
+            <div className="absolute top-[100%] z-10 mt-[14px] w-[366px] rounded-2xl border-[1.4px] bg-white p-2 shadow-shadow4">
+              {jobOptions.map((job) => (
+                <div
+                  key={job}
+                  className={`cursor-pointer gap-[10px] px-5 py-6 ${
+                    job === selectedJob
+                      ? 'text-purple-500 font-B01-SB'
+                      : 'text-gray-400 font-B01-M'
+                  }`}
+                  onClick={() => handleSelect(job)}
+                >
+                  {job}
+                </div>
+              ))}
+            </div>
+          )}
         </div>
 
         <div className="flex flex-row items-center gap-[6px]">
@@ -31,11 +75,22 @@ const Todo = () => {
       <div className="mt-[30px] flex w-full flex-col items-start rounded-[30px] border border-gray-300 bg-white p-[30px]">
         <div className="text-black font-T04-SB"> 할 일 목록</div>
         <Divider className="mb-4 mt-4" />
-        <CheckList
-          lists={list}
-          className="flex w-full flex-col items-center gap-8 pt-4"
-        />
-        <button className="mt-[26px] flex w-full items-center justify-center gap-[6px] rounded-2xl bg-purple-500 py-[14px] text-white font-T05-SB hover:bg-purple-600">
+
+        {list.length === 0 ? (
+          <div className="py-4 text-gray-500 font-B01-M">
+            아직 추가된 할 일이 없어요
+          </div>
+        ) : (
+          <CheckList
+            lists={list}
+            className="flex w-full flex-col items-center gap-8 py-4"
+          />
+        )}
+
+        <button
+          className="mt-[16px] flex w-full items-center justify-center gap-[6px] rounded-2xl bg-purple-500 py-[14px] text-white font-T05-SB hover:bg-purple-600"
+          onClick={() => navigate('/mytodo/add')}
+        >
           <Plus className="h-6 w-6" />
           추가하기
         </button>

--- a/src/pages/myTodo/components/todo/Todo.tsx
+++ b/src/pages/myTodo/components/todo/Todo.tsx
@@ -7,7 +7,7 @@ import Plus from '@assets/icons/plus.svg?react';
 import { useNavigate } from 'react-router-dom';
 
 const list = [
-  { text: '고용24에서 인근 요양보호사 과정 검색하기', hasMemo: true },
+  // { text: '고용24에서 인근 요양보호사 과정 검색하기', hasMemo: true },
   { text: '지역 교육기관 전화로 일정 문의하기' },
   { text: '지원서 작성용 사진 준비하기', hasMemo: true },
   { text: '건강검진 일정 잡기' },
@@ -32,7 +32,7 @@ const Todo = () => {
   };
 
   return (
-    <div className="mt-10 flex flex-col px-[120px]">
+    <div className="mb-[95px] mt-10 flex flex-col px-[120px]">
       <div className="flex flex-row justify-between">
         <div className="relative flex flex-col items-start">
           <div

--- a/src/pages/myTodo/tabs/TodoListPage.tsx
+++ b/src/pages/myTodo/tabs/TodoListPage.tsx
@@ -5,7 +5,7 @@ import ToggleButton from '@common/Toggle.tsx';
 
 const TodoListPage = () => {
   return (
-    <div className="mx-auto bg-gray-50 px-5 py-4">
+    <div className="mx-[120px] mt-10 bg-gray-50 px-5 py-4">
       <div className="mb-4 flex max-w-[1010px] flex-col gap-2">
         <div className="flex items-center gap-2 self-start">
           <BackIcon />

--- a/src/route/Router.tsx
+++ b/src/route/Router.tsx
@@ -15,6 +15,7 @@ import OtherTodoListPage from '@pages/otherTodoList/OtherTodoListPage.tsx';
 import MyTodoPage from '@pages/myTodo/MyTodoPage.tsx';
 import TodoListPage from '@pages/myTodo/tabs/TodoListPage.tsx';
 import ScrapPage from '@pages/myTodo/tabs/ScrapPage.tsx';
+import Todo from '@pages/myTodo/components/todo/Todo';
 
 const Router = () => {
   return (
@@ -37,7 +38,8 @@ const Router = () => {
           <Route path="/otherslist/:jobId" element={<OtherTodoListPage />} />
           <Route path="/mytodo" element={<MyTodoPage />}>
             <Route index element={<Navigate to="/mytodo/list" replace />} />
-            <Route path="list" element={<TodoListPage />} />
+            <Route path="list" element={<Todo />} />
+            <Route path="add" element={<TodoListPage />} />
             <Route path="scrap" element={<ScrapPage />} />
           </Route>
         </Route>


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안
- [x] 기능 추가  
- [ ] 기능 삭제  
- [ ] 버그 수정  
- [x] 스타일링  
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트  
- [ ] 기타  

## ✈️ 관련 이슈
<!-- 닫고자 하는 이슈 번호를 아래에 적어주세요. 예: close #(이슈번호) -->
close #124 

## 📋 작업 내용
<!-- 수정한 내용이나 추가한 기능에 대해 자세히 설명해 주세요. -->
-나의 할일 페이지 ui 구현

## 📸 스크린샷 (선택 사항)
<!-- 수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부할 수 있습니다. -->
![localhost_5173_mytodo_list (2)](https://github.com/user-attachments/assets/1c3c675d-fa69-47c2-8cc0-42fe0d8ba4f6)
![localhost_5173_mytodo_list (1)](https://github.com/user-attachments/assets/96bd786b-ec05-47bf-a27d-9016228ebecc)


## 📄 기타
<!-- 추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요. -->
`SidebarLayout`에 p-6이 있길래 뺐어요! 필요없던데...? 그리고 `TodoListPage.tsx`에서 mx 조정했어용
아니 근데 도대체 스크롤이 왜 생기는거지 이거 수정 좀 봐야할거같은데 자꾸 스크롤이 생기네,,,,

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 체크리스트에서 항목 삭제 및 삭제 취소(Undo) 기능이 추가되었습니다.
    - 체크리스트 항목에 메모 관련 UI 버튼(메모, 편집, 삭제)이 표시됩니다.
    - 할 일(Todo) 페이지에 직무 선택 드롭다운과 할 일 추가 버튼이 도입되었습니다.

- **UI/스타일 개선**
    - 토스트 알림창이 화면 상단 중앙에 고정되어 표시됩니다.
    - 할 일 목록 페이지의 여백 및 레이아웃이 개선되었습니다.
    - 사이드바에서 '/mytodo/add' 경로도 활성화 표시가 적용됩니다.
    - 특정 경로에서만 Footer가 표시됩니다.

- **버그 수정**
    - 내비게이션의 "나의 할일" 링크 경로가 '/mytodo/list'로 변경되었습니다.

- **기타**
    - 프로필 카드에서 버튼 클릭 시 다른 사용자의 리스트로 이동할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->