### PR TITLE
[🐛BUG] 로그인 이후, 온보딩 체크

### DIFF
--- a/src/hook/todo/useMdTodoQuery.ts
+++ b/src/hook/todo/useMdTodoQuery.ts
@@ -11,7 +11,7 @@ export const useMdTodoQuery = () => {
     queryKey: ['mdTodo'],
     queryFn: async () => {
       const { data } = await api.get('/v1/my-dream/todo');
-      console.log(data.data);
+
       return TodoDataSchema.parse(data.data);
     },
     staleTime: 1000 * 60 * 5,

--- a/src/hook/todo/useMdTodoQuery.ts
+++ b/src/hook/todo/useMdTodoQuery.ts
@@ -1,0 +1,30 @@
+import api from "@hook/api";
+import { useQuery } from "@tanstack/react-query";
+import { TodoData, TodoDataSchema } from "@validation/mydream/todoSchema";
+import { useNavigate } from "react-router-dom";
+import { useEffect } from "react";
+
+export const useMdTodoQuery = () => {
+  const navigate = useNavigate();
+  
+  const { data, isLoading, error } = useQuery<TodoData, Error>({
+    queryKey: ['mdTodo'],
+    queryFn: async () => {
+      const { data } = await api.get('/v1/my-dream/todo');
+      console.log(data.data);
+      return TodoDataSchema.parse(data.data);
+    },
+    staleTime: 1000 * 60 * 5,
+    refetchOnWindowFocus: false,
+    refetchOnMount: false,
+    retry: 1,
+  });
+
+  useEffect(() => {
+    if (data && (!data.todos || data.todos.length === 0)) {
+      navigate('/onboard');
+    }
+  }, [data, navigate]);
+
+  return { data, isLoading, error };
+};

--- a/src/hook/useLoginMutation.ts
+++ b/src/hook/useLoginMutation.ts
@@ -16,7 +16,6 @@ export const useLoginMutation = () => {
   return useMutation({
     mutationFn: login,
     onSuccess: (res) => {
-      console.log(res);
       if (res.success) {
         localStorage.setItem('accessToken', res.data.accessToken);
         localStorage.setItem('refreshToken', res.data.refreshToken);

--- a/src/pages/home/components/LoginBanner.tsx
+++ b/src/pages/home/components/LoginBanner.tsx
@@ -7,44 +7,59 @@ import { useUserStore } from '@store/useUserStore';
 import { useNavigate } from 'react-router-dom';
 import { useFilterStore } from '@store/filterStore';
 import CheckList from '@common/CheckList';
-
-const challengeList = [
-  'wwwwwwwwwwwwwwwwwwwwwwwwwwwwwww ...',
-  'wwwwwwwwwwwwwwwwwwwwwwwwwwwwwww ...',
-  'wwwwwwwwwwwwwwwwwwwwwwwwwwwwwww ...',
-  'wwwwwwwwwwwwwwwwwwwwwwwwwwwwwww ...',
-];
+import { useMdTodoQuery } from '@hook/todo/useMdTodoQuery';
+import { useMemo } from 'react';
 
 const LoginBanner = () => {
   const { data: jobList } = useBannerQuery();
   const regionName = useUserStore((state) => state.regionName);
   const navigate = useNavigate();
   const setSelection = useFilterStore((state) => state.setSelection);
+  const { data: todoData, isLoading } = useMdTodoQuery();
+  
 
+  const todoItems = useMemo(() => {
+    if (!todoData || !todoData.todos) return [];
+    
+    return todoData.todos
+      .filter(todo => !todo.completed)
+      .slice(0, 4)
+      .map(todo => todo.title);
+  }, [todoData]);
+  
   return (
     <div className="flex h-[489px] w-full flex-row items-center justify-center space-x-5 bg-purple-150 px-[120px] pb-[50px] pt-[60px]">
       <div className="relative flex flex-row gap-6">
         <LoginHomeCard />
 
-        <div className="absolute right-0 flex w-[162px] cursor-pointer items-center gap-2 rounded-full bg-white py-[6px] pl-4 pr-1">
+        <div 
+          className="absolute right-0 flex w-[162px] cursor-pointer items-center gap-2 rounded-full bg-white py-[6px] pl-4 pr-1"
+    
+        >
           <span className="text-gray-500 font-B02-SB"> 나의 할일 가기</span>
           <MyDreamArrow />
         </div>
 
         <div className="absolute left-[30px] top-10 flex flex-col">
-          <span className="text-white font-B02-M"> 58일째 꿈꾸는중</span>
+          <span className="text-white font-B02-M">
+            {todoData ? `${todoData.daysAgo}일째 꿈꾸는중` : '꿈꾸는중'}
+          </span>
 
           <div className="mt-[10px] text-white font-T01-B">
-            요양보호사 시작하는 중
+            {todoData && todoData.jobName ? `${todoData.jobName} 시작하는 중` : '직업 준비중'}
           </div>
         </div>
 
         <div className="absolute">
           <div className="absolute bottom-0 left-[30px] top-[255px] flex items-center justify-center">
-            <CheckList
-              lists={challengeList}
-              className="my-6 flex flex-col gap-4"
-            />
+            {isLoading ? (
+              <div className="text-white">로딩중...</div>
+            ) : (
+              <CheckList
+                lists={todoItems.length > 0 ? todoItems : ['할일을 추가해주세요']}
+                className="my-6 flex flex-col gap-4"
+              />
+            )}
           </div>
         </div>
       </div>

--- a/src/pages/myTodo/components/todo/Todo.tsx
+++ b/src/pages/myTodo/components/todo/Todo.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState, useRef } from 'react';
 import BackIcon from '@assets/icons/back.svg?react';
 import Eye from '@assets/icons/show_pw.svg?react';
 import CheckList from '@common/CheckList';
@@ -19,6 +19,19 @@ const jobOptions = ['간호 조무사', '바리스타', '요양보호사'];
 
 const Todo = () => {
   const navigate = useNavigate();
+  const alertShown = useRef(false);
+  
+  useEffect(() => {
+    const accessToken = localStorage.getItem('accessToken');
+    console.log(accessToken);
+    
+    if (!accessToken && !alertShown.current) {
+      alertShown.current = true;
+      alert('로그인 후 이용해주세요');
+      navigate('/');
+    }
+  }, [navigate]);
+  
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const [selectedJob, setSelectedJob] = useState('요양보호사');
 

--- a/src/pages/myTodo/components/todo/Todo.tsx
+++ b/src/pages/myTodo/components/todo/Todo.tsx
@@ -20,18 +20,17 @@ const jobOptions = ['간호 조무사', '바리스타', '요양보호사'];
 const Todo = () => {
   const navigate = useNavigate();
   const alertShown = useRef(false);
-  
+
   useEffect(() => {
     const accessToken = localStorage.getItem('accessToken');
-    console.log(accessToken);
-    
+
     if (!accessToken && !alertShown.current) {
       alertShown.current = true;
       alert('로그인 후 이용해주세요');
       navigate('/');
     }
   }, [navigate]);
-  
+
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const [selectedJob, setSelectedJob] = useState('요양보호사');
 

--- a/src/pages/otherTodo/OtherTodoPage.tsx
+++ b/src/pages/otherTodo/OtherTodoPage.tsx
@@ -13,13 +13,13 @@ const ITEMS_PER_PAGE = 3;
 const suyiGroups = [
   [
     '아롱이 병원에 들렀을 때, 늘 친절하신 간호 선생님께 취업 경로 살짝 여쭤보기',
-    '요즘 정부지원 교육 많다던데, 중랑구 복지센터에 전화해서 “교육 중에 동물 관련된 것도 있나요?” 물어보기.',
+    '요즘 정부지원 교육 많다던데, 중랑구 복지센터에 전화해서 "교육 중에 동물 관련된 것도 있나요?" 물어보기.',
     '동물보건사 자격증은 꼭 필요한지, 아니면 반려동물 키워본 경험만으로도 가능한지 알아보기',
   ],
   [
     '대전시 평생학습관 홈페이지 들어가서 동물 관련 수업 있는지 확인하기',
     '한 달에 한 번, 가까운 유기견 보호소에 봉사 문의해보기',
-    '네이버카페 ‘대전동물사랑’ 봉사팀 가입하면 유기견 봉사 일정 확인할 수 있다.',
+    "네이버카페 '대전동물사랑' 봉사팀 가입하면 유기견 봉사 일정 확인할 수 있다.",
   ],
   [
     '동물보건과가 있는 전문대학 찾아보기: 중부대학교, 연성대학교',
@@ -32,31 +32,35 @@ const simriGroups = [
   [
     '행복심리상담센터에 방문해서 상담사에게 취업 경로 여쭤보기',
     '중랑구복지센터에 전화해서 심리 자격증 관련 과정 물어보기 (02-1930-4609)',
-    '성동구 평생학습관에서 ‘심리학’ 관련 수업 있는지 홈페이지 먼저 살펴보기',
+    "성동구 평생학습관에서 '심리학' 관련 수업 있는지 홈페이지 먼저 살펴보기",
   ],
   [
-    '서울여성인력개발원 홈페이지에서 ‘심리상담사 양성과정’ 개강 일정 확인 (다음 개강이 6월 둘째주→ 달력에 표시하기)',
+    "서울여성인력개발원 홈페이지에서 '심리상담사 양성과정' 개강 일정 확인 (다음 개강이 6월 둘째주→ 달력에 표시하기)",
     '중랑여성인력개발센터 상담과정 수강 일정 체크하기',
     '상담 자격증 교육비 알아보기 (서울여성인력개발원: 40만원대, 사설: 65만원-국비 지원 미포함)',
   ],
   [
     '심리상담사 수료증 받자마자 실습기관 2곳에 지원하기 (마음쉼터상담소, 행복심리상담센터)',
     '실습일지 양식 출력해두기 (한국상담학회 양식 기준)- 하루 2회 이상 작성',
-    '면접 준비용 자기소개서 초안 작성하기 (“왜 심리상담사가 되고 싶은가요?” 질문에 대한 답변부터 정리 시작!)',
+    '면접 준비용 자기소개서 초안 작성하기 ("왜 심리상담사가 되고 싶은가요?" 질문에 대한 답변부터 정리 시작!)',
   ],
 ];
 
 const OtherTodoPage = () => {
   const navigate = useNavigate();
   const { jobId } = useParams<{ jobId?: string }>();
-  if (!jobId || Number.isNaN(Number(jobId))) {
-    navigate(-1); // 또는 에러 페이지
-    return null;
-  }
-  const numericJobId = Number(jobId);
   const [currentPage, setCurrentPage] = useState(0);
 
+  const isValidJobId = jobId && !Number.isNaN(Number(jobId));
+  const numericJobId = isValidJobId ? Number(jobId) : -1;
+
   const { data: jobDetail, isPending } = useJobDetailQuery(numericJobId);
+
+  if (!isValidJobId) {
+    navigate(-1);
+    return null;
+  }
+
   if (isPending || !jobDetail) {
     return (
       <div className="flex h-[300px] items-center justify-center">

--- a/src/validation/mydream/todoSchema.ts
+++ b/src/validation/mydream/todoSchema.ts
@@ -1,0 +1,21 @@
+import { z } from 'zod';
+
+export const TodoSchema = z.object({
+  todoId: z.number(),
+  title: z.string(),
+  completed: z.boolean(),
+  isMemoExist: z.boolean(),
+  isPublic: z.boolean(),
+});
+
+export const TodoDataSchema = z.object({
+  todoGroupId: z.number(),
+  memberNickname: z.string(),
+  daysAgo: z.number(),
+  jobName: z.string(),
+  totalView: z.number(),
+  todos: z.array(TodoSchema),
+});
+
+export type Todo = z.infer<typeof TodoSchema>;
+export type TodoData = z.infer<typeof TodoDataSchema>; 


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안
- [x] 기능 추가  
- [ ] 기능 삭제  
- [x] 버그 수정  
- [ ] 스타일링  
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트  
- [ ] 기타  

## ✈️ 관련 이슈
<!-- 닫고자 하는 이슈 번호를 아래에 적어주세요. 예: close #(이슈번호) -->


## 📋 작업 내용
<!-- 수정한 내용이나 추가한 기능에 대해 자세히 설명해 주세요. -->
/my-dream/todo api 연결
todos가 비어있으면 onboard로 이동되도록 코드 수정

## 📸 스크린샷 (선택 사항)
<!-- 수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부할 수 있습니다. -->
<img width="1510" alt="image" src="https://github.com/user-attachments/assets/8d7ae0fa-66fa-4cef-a11c-f636bac32454" />


## 📄 기타
<!-- 추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - "My Dream" 투두 데이터를 불러오는 기능이 추가되어, 홈 배너에서 할 일 목록이 동적으로 표시됩니다.
  - 투두 데이터가 없을 경우 온보딩 화면으로 자동 이동하는 기능이 추가되었습니다.
  - 인증되지 않은 사용자가 투두 페이지 접근 시 로그인 안내 후 리다이렉트됩니다.
- **버그 수정**
  - 로그인 성공 시 불필요한 콘솔 로그가 제거되었습니다.
- **스타일/사용성**
  - 투두 데이터 로딩 상태 및 빈 목록에 대한 사용자 안내가 개선되었습니다.
- **문서화**
  - 투두 데이터의 유효성을 검증하는 스키마가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->