### PR TITLE
[✨FEATURE] 타유저 투두리스트 메모 조회

### DIFF
--- a/src/common/CheckList.tsx
+++ b/src/common/CheckList.tsx
@@ -106,13 +106,6 @@ const CheckList = ({
     }
   };
 
-  const handleMeMo = (index: number) => {
-    const item = listItems[index];
-    if (item.id) {
-      navigate(`/mytodo/memo/${item.id}`);
-    }
-  };
-
   return (
     <div className={className}>
       {listItems.map(({ text, hasMemo, id }, idx) => {
@@ -146,10 +139,7 @@ const CheckList = ({
             {hasMemo && (
               <div className="group ml-auto flex min-w-fit items-center gap-[5px]">
                 <button className="flex items-center gap-[6px] rounded-[10px] bg-purple-100 px-3 py-2 text-purple-500 font-B03-SB">
-                  <MemoIcon
-                    className="h-[18px] w-[18px] text-purple-500"
-                    onClick={() => handleMeMo(idx)}
-                  />
+                  <MemoIcon className="h-[18px] w-[18px] text-purple-500" />
                   메모
                 </button>
                 <div className="flex flex-row gap-[5px] opacity-0 transition-opacity duration-200 group-hover:opacity-100">

--- a/src/common/CheckList.tsx
+++ b/src/common/CheckList.tsx
@@ -106,6 +106,13 @@ const CheckList = ({
     }
   };
 
+  const handleMeMo = (index: number) => {
+    const item = listItems[index];
+    if (item.id) {
+      navigate(`/mytodo/memo/${item.id}`);
+    }
+  };
+
   return (
     <div className={className}>
       {listItems.map(({ text, hasMemo, id }, idx) => {
@@ -139,7 +146,10 @@ const CheckList = ({
             {hasMemo && (
               <div className="group ml-auto flex min-w-fit items-center gap-[5px]">
                 <button className="flex items-center gap-[6px] rounded-[10px] bg-purple-100 px-3 py-2 text-purple-500 font-B03-SB">
-                  <MemoIcon className="h-[18px] w-[18px] text-purple-500" />
+                  <MemoIcon
+                    className="h-[18px] w-[18px] text-purple-500"
+                    onClick={() => handleMeMo(idx)}
+                  />
                   메모
                 </button>
                 <div className="flex flex-row gap-[5px] opacity-0 transition-opacity duration-200 group-hover:opacity-100">

--- a/src/hook/mydream/useGetMemo.ts
+++ b/src/hook/mydream/useGetMemo.ts
@@ -1,0 +1,41 @@
+import { useQuery, UseQueryOptions } from '@tanstack/react-query';
+import api from '@hook/api.ts';
+
+export interface GetMemoProps {
+  todoId: number;
+  title: string;
+  isPublic: boolean;
+  memoText: string;
+  images: {
+    imageId: number;
+    imageUrl: string;
+  }[];
+}
+
+const GetMemo = async (todoId: number): Promise<GetMemoProps> => {
+  const token = localStorage.getItem('accessToken');
+
+  if (!token) throw new Error('토큰이 없습니다.');
+
+  const response = await api.get(`/v1/todo/${todoId}/memo`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+  console.log('memo', response.data);
+  return response.data.data;
+};
+
+export const useMemoQuery = (
+  todoId: number,
+  options?: Omit<
+    UseQueryOptions<GetMemoProps, Error, GetMemoProps, [string, number]>,
+    'queryKey' | 'queryFn'
+  >
+) => {
+  return useQuery<GetMemoProps, Error, GetMemoProps, [string, number]>({
+    queryKey: ['GetMemo', todoId],
+    queryFn: () => GetMemo(todoId),
+    ...options,
+  });
+};

--- a/src/hook/useJobQuery.ts
+++ b/src/hook/useJobQuery.ts
@@ -9,6 +9,7 @@ export interface JobRequest {
   workTimeInfo: string;
   physicalInfo: string;
   imageUrl: string;
+  todoGroupNum: number;
 }
 
 export interface JobDetailRequest {

--- a/src/outlet/SidebarLayout.tsx
+++ b/src/outlet/SidebarLayout.tsx
@@ -20,7 +20,8 @@ const SidebarLayout = ({ children }: SidebarLayoutProps) => {
                 to="/mytodo/list"
                 className={`block w-full rounded-2xl px-4 py-3 text-left font-B01-B ${
                   pathname.includes('/mytodo/list') ||
-                  pathname.includes('/mytodo/add')
+                  pathname.includes('/mytodo/add') ||
+                  pathname.includes('/mytodo/memo')
                     ? 'bg-purple-100 text-purple-500'
                     : 'text-gray-400 hover:text-purple-500'
                 }`}

--- a/src/pages/jobfound/components/ListFound.tsx
+++ b/src/pages/jobfound/components/ListFound.tsx
@@ -82,7 +82,7 @@ const ListFound = ({ page, setTotalPages }: ListFoundProps) => {
                     <UserIcon className="h-6 w-6" />
                     <div className="text-gray-500 font-B03-M">
                       {' '}
-                      100명이 준비중{' '}
+                      {item.todoGroupNum}명이 준비중{' '}
                     </div>
                   </div>
                 </div>

--- a/src/pages/myTodo/components/todo/AutoTextArea.tsx
+++ b/src/pages/myTodo/components/todo/AutoTextArea.tsx
@@ -6,12 +6,18 @@ interface Props {
   value: string;
   onChange: (value: string) => void;
   maxLength?: number;
+  readOnly?: boolean;
 }
 
 const youtubeRegex =
   /(?:https?:\/\/)?(?:www\.)?(?:youtube\.com\/watch\?v=|youtu\.be\/)([\w-]{11})/;
 
-const AutoTextArea = ({ value, onChange, maxLength = 5000 }: Props) => {
+const AutoTextArea = ({
+  value,
+  onChange,
+  maxLength = 5000,
+  readOnly = false,
+}: Props) => {
   const editorRef = useRef<HTMLDivElement>(null);
   const [videoId, setVideoId] = useState<string | null>(null);
 
@@ -102,11 +108,11 @@ const AutoTextArea = ({ value, onChange, maxLength = 5000 }: Props) => {
     <div className="w-full">
       <div
         ref={editorRef}
-        contentEditable
+        contentEditable={!readOnly}
         onInput={handleInput}
         suppressContentEditableWarning
         data-placeholder="자유롭게 메모를 입력하세요"
-        className={`max-h-[520px] min-h-[48px] w-full overflow-y-auto whitespace-pre-wrap rounded-lg border border-gray-300 p-3 text-sm text-gray-800 focus:outline-none focus:ring-2 focus:ring-blue-400`}
+        className={`max-h-[520px] min-h-[48px] w-full overflow-y-auto whitespace-pre-wrap rounded-lg border border-gray-300 p-3 text-sm text-gray-800 focus:outline-none ${readOnly ? '' : 'focus:ring-2 focus:ring-blue-400'}`}
       />
     </div>
   );

--- a/src/pages/myTodo/components/todo/MyEditor.tsx
+++ b/src/pages/myTodo/components/todo/MyEditor.tsx
@@ -8,9 +8,10 @@ const MAX_LENGTH = 5000;
 interface MyEditorProps {
   value: string;
   onChange: (text: string) => void;
+  readOnly?: boolean;
 }
 
-const MyEditor = ({ value, onChange }: MyEditorProps) => {
+const MyEditor = ({ value, onChange, readOnly = false }: MyEditorProps) => {
   const [localValue, setLocalValue] = useState(value);
 
   useEffect(() => {
@@ -40,10 +41,11 @@ const MyEditor = ({ value, onChange }: MyEditorProps) => {
         value={localValue}
         onChange={handleChange}
         maxLength={MAX_LENGTH}
+        readOnly={readOnly}
       />
       <div className="mt-4">
         <h2 className="text-lg font-bold text-gray-900">링크 미리보기</h2>
-        <LinkEditor />
+        <LinkEditor readOnly={readOnly} />
       </div>
     </div>
   );

--- a/src/pages/otherTodoList/components/TodoCard.tsx
+++ b/src/pages/otherTodoList/components/TodoCard.tsx
@@ -1,8 +1,8 @@
-import { useState } from 'react';
 import CheckIcon from '@assets/icons/check.svg?react';
 import MemoIcon from '@assets/icons/memo.svg?react';
 import ReWriteIcon from '@assets/icons/edit-write.svg?react';
 import TrashIcon from '@assets/icons/delete-trash.svg?react';
+import { useNavigate } from 'react-router-dom';
 
 interface TodoItem {
   todoId: number;
@@ -25,15 +25,7 @@ const TodoCard = ({
   showAddButton = false,
   disableHover = false,
 }: TodoCardProps) => {
-  const [todoList, setTodoList] = useState(todos);
-
-  const toggleCheck = (index: number) => {
-    setTodoList((prev) =>
-      prev.map((item, i) =>
-        i === index ? { ...item, completed: !item.completed } : item
-      )
-    );
-  };
+  const navigate = useNavigate();
 
   return (
     <div className="flex flex-col justify-between rounded-[30px] border border-gray-300 bg-white p-[30px]">
@@ -42,7 +34,7 @@ const TodoCard = ({
       </div>
 
       <ul className="w-full flex-grow space-y-4">
-        {todoList.map((item, index) => (
+        {todos.map((item, index) => (
           <li
             key={index}
             className={`flex items-center px-2 py-1 ${
@@ -50,7 +42,6 @@ const TodoCard = ({
             }`}
           >
             <div
-              onClick={() => toggleCheck(index)}
               className={`flex h-[30px] w-[30px] cursor-pointer items-center justify-center rounded-[8px] border ${
                 item.completed
                   ? 'border-purple-300 bg-purple-150'
@@ -72,7 +63,10 @@ const TodoCard = ({
 
             <div className="flex min-w-fit items-center gap-2">
               {item.isMemoExist && (
-                <button className="flex items-center gap-1 rounded-xl bg-purple-100 px-4 py-2 text-purple-500 font-B03-SB">
+                <button
+                  className="flex items-center gap-1 rounded-xl bg-purple-100 px-4 py-2 text-purple-500 font-B03-SB"
+                  onClick={() => navigate(`/mytodo/memo/${item.todoId}`)}
+                >
                   <MemoIcon className="h-4 w-4 text-purple-500" />
                   메모
                 </button>

--- a/src/route/Router.tsx
+++ b/src/route/Router.tsx
@@ -45,6 +45,7 @@ const Router = () => {
             <Route path="list" element={<Todo />} />
             <Route path="add/:todoGroupId" element={<TodoListPage />} />
             <Route path="edit/:todoId" element={<TodoListPage />} />
+            <Route path="memo/:todoId" element={<TodoListPage />} />
             <Route path="scrap" element={<ScrapPage />} />
           </Route>
           <Route path="/mypage" element={<Mypage />} />

--- a/src/utils/preview/LinkEditor.tsx
+++ b/src/utils/preview/LinkEditor.tsx
@@ -3,11 +3,16 @@ import { LinkPreview } from './LinkPreview';
 
 const urlRegex = /(https?:\/\/[^\sㄱ-ㅎㅏ-ㅣ가-힣]+)/g;
 
-export default function LinkEditor() {
+interface LinkEditorProps {
+  readOnly?: boolean;
+}
+
+export default function LinkEditor({ readOnly = false }: LinkEditorProps) {
   const editorRef = useRef<HTMLDivElement>(null);
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
 
   const handleInput = () => {
+    if (readOnly) return;
     const content = editorRef.current?.innerText || '';
     const match = content.match(urlRegex);
     if (match && match[0] !== previewUrl) {
@@ -19,7 +24,7 @@ export default function LinkEditor() {
     <div className="space-y-2">
       <div
         ref={editorRef}
-        contentEditable
+        contentEditable={!readOnly}
         onInput={handleInput}
         className="min-h-[40px] w-full max-w-[562px] rounded-[10px] border border-gray-300 p-2 text-xs focus:outline-none"
         placeholder="링크를 입력해보세요"


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안
- [x] 기능 추가  
- [ ] 기능 삭제  
- [ ] 버그 수정  
- [ ] 스타일링  
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트  
- [ ] 기타  

## ✈️ 관련 이슈
<!-- 닫고자 하는 이슈 번호를 아래에 적어주세요. 예: close #(이슈번호) -->
close #171 

## 📋 작업 내용
<!-- 수정한 내용이나 추가한 기능에 대해 자세히 설명해 주세요. -->
- 직업 준비중 api 인원 추가
- 타 유저 메모 보기 추가

## 📸 스크린샷 (선택 사항)
<!-- 수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부할 수 있습니다. -->
<img width="716" alt="image" src="https://github.com/user-attachments/assets/91ff0a66-3fed-4861-97af-f757dc0340c0" />


## 📄 기타
<!-- 추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 할 일 항목의 메모 아이콘 클릭 시 해당 메모 상세 페이지로 이동할 수 있는 기능이 추가되었습니다.
  - 할 일의 메모 데이터를 조회하는 기능이 추가되었습니다.
  - 할 일 상세 및 메모 상세 페이지에서 읽기 전용(수정 불가) 모드가 지원됩니다.
  - 할 일 메모 상세 페이지로 이동하는 라우트가 추가되었습니다.

- **개선 사항**
  - 직업 준비 인원 표시가 고정값에서 실제 데이터 기반으로 변경되었습니다.
  - 메모 상세 페이지 진입 시, 제목 및 공개 여부 표시가 메모 데이터 기준으로 동작합니다.
  - 읽기 전용 모드에서는 입력창 및 에디터, 링크 미리보기가 비활성화됩니다.
  - 사이드바에서 메모 상세 페이지 진입 시에도 할 일 목록이 활성화 표시됩니다.

- **버그 수정**
  - 할 일 카드에서 메모 버튼 클릭 시, 해당 메모 상세 페이지로 정상 이동합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->