### PR TITLE
[✨FEATURE] 다른 드리머 ui 수정

### DIFF
--- a/src/assets/icons/check.svg
+++ b/src/assets/icons/check.svg
@@ -1,3 +1,3 @@
 <svg width="19" height="20" viewBox="0 0 19 20" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M15.8845 5.38477L7.423 13.8463L3.57684 10.0002" stroke="#4F469C" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M15.8845 5.38477L7.423 13.8463L3.57684 10.0002" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>

--- a/src/assets/icons/save.svg
+++ b/src/assets/icons/save.svg
@@ -1,0 +1,4 @@
+<svg width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M14.8462 14.9231C14.8462 15.2087 14.7327 15.4826 14.5307 15.6846C14.3288 15.8865 14.0548 16 13.7692 16H4.07692C3.79131 16 3.51739 15.8865 3.31542 15.6846C3.11346 15.4826 3 15.2087 3 14.9231V3.07692C3 2.79131 3.11346 2.51739 3.31542 2.31542C3.51739 2.11346 3.79131 2 4.07692 2H9.46154L14.8462 7.38462V14.9231Z" stroke="#676F7B" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M6.23077 10.6136L7.84616 11.6905L10.5385 7.38281" stroke="#676F7B" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/common/CheckList.tsx
+++ b/src/common/CheckList.tsx
@@ -8,6 +8,7 @@ import TrashIcon from '@assets/icons/delete-trash.svg?react';
 import ToastModal from './modal/ToastModal';
 import Info from '@assets/icons/info.svg?react';
 import { useDeleteTodoMutation } from '@hook/todo/useDeleteTodoMutation';
+import { useUpdateMemoMutation } from '@hook/mydream/useUpdateMemoMutation.ts';
 
 type ChecklistItem =
   | string
@@ -33,7 +34,7 @@ const CheckList = ({
   const navigate = useNavigate();
   const location = useLocation();
   const isMyToPage = location.pathname.startsWith('/mytodo/list');
-
+  const { mutate: updateTodo } = useUpdateMemoMutation();
   const normalized = lists.map((item) =>
     typeof item === 'string' ? { text: item } : item
   );
@@ -60,6 +61,27 @@ const CheckList = ({
       next = [...checkedIds, id];
     }
     onChange?.(next);
+  };
+
+  const handleSaveEdit = () => {
+    if (editIndex === null) return;
+    const item = listItems[editIndex];
+    if (!item.id) return;
+
+    updateTodo({
+      todoId: item.id,
+      todoTitle: editText,
+      isPublic: true,
+    });
+
+    const newItems = [...listItems];
+    newItems[editIndex] = {
+      ...item,
+      text: editText,
+    };
+    setListItems(newItems);
+    setEditIndex(null);
+    setEditText('');
   };
 
   const handleDelete = (index: number) => {
@@ -110,18 +132,6 @@ const CheckList = ({
     const item = listItems[index];
     setEditIndex(index);
     setEditText(item.text);
-  };
-
-  const handleSaveEdit = () => {
-    if (editIndex === null) return;
-    const newItems = [...listItems];
-    newItems[editIndex] = {
-      ...newItems[editIndex],
-      text: editText,
-    };
-    setListItems(newItems);
-    setEditIndex(null);
-    setEditText('');
   };
 
   const handleCancelEdit = () => {

--- a/src/common/CheckList.tsx
+++ b/src/common/CheckList.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import Check from '@assets/icons/check.svg?react';
+import SaveIcon from '@assets/icons/save.svg?react';
 import MemoIcon from '@assets/icons/memo.svg?react';
 import ReWriteIcon from '@assets/icons/edit-write.svg?react';
 import TrashIcon from '@assets/icons/delete-trash.svg?react';
@@ -44,6 +45,9 @@ const CheckList = ({
     index: number;
     checked: boolean;
   } | null>(null);
+
+  const [editIndex, setEditIndex] = useState<number | null>(null);
+  const [editText, setEditText] = useState<string>('');
 
   const deleteTodoMutation = useDeleteTodoMutation();
 
@@ -104,9 +108,25 @@ const CheckList = ({
 
   const handleEdit = (index: number) => {
     const item = listItems[index];
-    if (item.id) {
-      navigate(`/mytodo/edit/${item.id}`);
-    }
+    setEditIndex(index);
+    setEditText(item.text);
+  };
+
+  const handleSaveEdit = () => {
+    if (editIndex === null) return;
+    const newItems = [...listItems];
+    newItems[editIndex] = {
+      ...newItems[editIndex],
+      text: editText,
+    };
+    setListItems(newItems);
+    setEditIndex(null);
+    setEditText('');
+  };
+
+  const handleCancelEdit = () => {
+    setEditIndex(null);
+    setEditText('');
   };
 
   const handleViewMemo = (index: number) => {
@@ -120,6 +140,7 @@ const CheckList = ({
     <div className={className}>
       {listItems.map(({ text, hasMemo, id }, idx) => {
         const done = id !== undefined && checkedIds.includes(id);
+        const isEditing = editIndex === idx;
 
         return (
           <div
@@ -137,13 +158,22 @@ const CheckList = ({
               >
                 {done && <Check className="h-[19px] w-[19px]" />}
               </div>
-              <div
-                className={`w-[622px] truncate font-B02-M ${
-                  done ? 'text-gray-500' : 'text-gray-800'
-                }`}
-              >
-                {text}
-              </div>
+              {isEditing ? (
+                <input
+                  value={editText}
+                  onChange={(e) => setEditText(e.target.value)}
+                  className="w-[622px] rounded-md border border-gray-300 px-3 py-2 text-gray-800 font-B02-M"
+                  autoFocus
+                />
+              ) : (
+                <div
+                  className={`w-[622px] truncate font-B02-M ${
+                    done ? 'text-gray-500' : 'text-gray-800'
+                  }`}
+                >
+                  {text}
+                </div>
+              )}
             </div>
 
             <div className="ml-auto flex min-w-fit items-center gap-[5px]">
@@ -159,20 +189,41 @@ const CheckList = ({
 
               {isMyToPage && (
                 <div className="flex flex-row gap-[5px] opacity-0 transition-opacity duration-200 group-hover:opacity-100">
-                  <button
-                    onClick={() => handleEdit(idx)}
-                    className="flex items-center gap-[6px] rounded-[10px] bg-gray-100 px-3 py-2 text-gray-500 font-B03-SB"
-                  >
-                    <ReWriteIcon className="h-[18px] w-[18px]" />
-                    편집
-                  </button>
-                  <button
-                    onClick={() => handleDelete(idx)}
-                    className="flex items-center gap-[6px] rounded-[10px] bg-gray-100 px-3 py-2 text-gray-500 font-B03-SB"
-                  >
-                    <TrashIcon className="h-[18px] w-[18px]" />
-                    삭제
-                  </button>
+                  {isEditing ? (
+                    <>
+                      <button
+                        onClick={handleSaveEdit}
+                        className="flex items-center gap-[6px] rounded-[10px] bg-gray-100 px-3 py-2 text-gray-500 font-B03-SB"
+                      >
+                        <SaveIcon className="h-[18px] w-[18px] text-purple-500" />
+                        저장
+                      </button>
+                      <button
+                        onClick={handleCancelEdit}
+                        className="flex items-center gap-[6px] rounded-[10px] bg-gray-100 px-3 py-2 text-gray-500 font-B03-SB"
+                      >
+                        <TrashIcon className="h-[18px] w-[18px]" />
+                        취소
+                      </button>
+                    </>
+                  ) : (
+                    <>
+                      <button
+                        onClick={() => handleEdit(idx)}
+                        className="flex items-center gap-[6px] rounded-[10px] bg-gray-100 px-3 py-2 text-gray-500 font-B03-SB"
+                      >
+                        <ReWriteIcon className="h-[18px] w-[18px]" />
+                        편집
+                      </button>
+                      <button
+                        onClick={() => handleDelete(idx)}
+                        className="flex items-center gap-[6px] rounded-[10px] bg-gray-100 px-3 py-2 text-gray-500 font-B03-SB"
+                      >
+                        <TrashIcon className="h-[18px] w-[18px]" />
+                        삭제
+                      </button>
+                    </>
+                  )}
                 </div>
               )}
             </div>

--- a/src/common/CheckList.tsx
+++ b/src/common/CheckList.tsx
@@ -1,8 +1,7 @@
 import { useState } from 'react';
-import { useNavigate, useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
 import Check from '@assets/icons/check.svg?react';
 import SaveIcon from '@assets/icons/save.svg?react';
-import MemoIcon from '@assets/icons/memo.svg?react';
 import ReWriteIcon from '@assets/icons/edit-write.svg?react';
 import TrashIcon from '@assets/icons/delete-trash.svg?react';
 import ToastModal from './modal/ToastModal';
@@ -31,7 +30,6 @@ const CheckList = ({
   className = '',
   onChange,
 }: CheckListProps) => {
-  const navigate = useNavigate();
   const location = useLocation();
   const isMyToPage = location.pathname.startsWith('/mytodo/list');
   const { mutate: updateTodo } = useUpdateMemoMutation();
@@ -139,16 +137,9 @@ const CheckList = ({
     setEditText('');
   };
 
-  const handleViewMemo = (index: number) => {
-    const item = listItems[index];
-    if (item.id) {
-      navigate(`/mytodo/memo/${item.id}`);
-    }
-  };
-
   return (
     <div className={className}>
-      {listItems.map(({ text, hasMemo, id }, idx) => {
+      {listItems.map(({ text, id }, idx) => {
         const done = id !== undefined && checkedIds.includes(id);
         const isEditing = editIndex === idx;
 
@@ -187,16 +178,6 @@ const CheckList = ({
             </div>
 
             <div className="ml-auto flex min-w-fit items-center gap-[5px]">
-              {hasMemo && (
-                <button
-                  className="flex items-center gap-[6px] rounded-[10px] bg-purple-100 px-3 py-2 text-purple-500 font-B03-SB"
-                  onClick={() => handleViewMemo(idx)}
-                >
-                  <MemoIcon className="h-[18px] w-[18px] text-purple-500" />
-                  메모
-                </button>
-              )}
-
               {isMyToPage && (
                 <div className="flex flex-row gap-[5px] opacity-0 transition-opacity duration-200 group-hover:opacity-100">
                   {isEditing ? (

--- a/src/pages/myTodo/components/todo/EmptyTodo.tsx
+++ b/src/pages/myTodo/components/todo/EmptyTodo.tsx
@@ -7,15 +7,15 @@ interface Props {
 
 const EmptyTodo = ({ onNavigate }: Props) => (
   <div className="flex min-h-[500px] flex-col items-center justify-center space-y-4">
-    <img src={WarningImg} alt="스크랩 비어 있음" className="h-32 w-32" />
     <h2 className="text-gray-900 font-T02-B">담은 직업이 아직 없어요!</h2>
     <p className="text-center text-gray-500 font-B02-M">
       할일 목록을 이용하시려면,
       <br />
       우선 관심 직업 1개를 담아주세요
     </p>
+    <img src={WarningImg} alt="스크랩 비어 있음" className="h-32 w-32" />
     <Button
-      text={'직업 정보 둘러보기'}
+      text={'직업 담으러 가기'}
       className="h-[62px] w-[242px] font-T05-SB"
       onClick={onNavigate}
     />

--- a/src/pages/myTodo/components/todo/EmptyTodo.tsx
+++ b/src/pages/myTodo/components/todo/EmptyTodo.tsx
@@ -8,10 +8,11 @@ interface Props {
 const EmptyTodo = ({ onNavigate }: Props) => (
   <div className="flex min-h-[500px] flex-col items-center justify-center space-y-4">
     <img src={WarningImg} alt="스크랩 비어 있음" className="h-32 w-32" />
-    <h2 className="text-gray-900 font-T02-B">아직 담은 직업 정보가 없어요!</h2>
+    <h2 className="text-gray-900 font-T02-B">담은 직업이 아직 없어요!</h2>
     <p className="text-center text-gray-500 font-B02-M">
-      투두리스트는 관심 있는 직업을 먼저 담은 뒤,
-      <br />그 직업에 맞춰 작성하고 관리할 수 있어요!
+      할일 목록을 이용하시려면,
+      <br />
+      우선 관심 직업 1개를 담아주세요
     </p>
     <Button
       text={'직업 정보 둘러보기'}

--- a/src/pages/myTodo/components/todo/Todo.tsx
+++ b/src/pages/myTodo/components/todo/Todo.tsx
@@ -148,7 +148,11 @@ const Todo = () => {
   }
 
   if (!jobsData || !Array.isArray(jobsData) || jobsData.length === 0) {
-    return <EmptyTodo onNavigate={() => navigate('/jobsearch')} />;
+    return (
+      <div className="flex h-screen items-center justify-center">
+        <EmptyTodo onNavigate={() => navigate('/jobsearch')} />
+      </div>
+    );
   }
 
   const selectedJobName = Array.isArray(jobsData)

--- a/src/pages/myTodo/components/todo/Todo.tsx
+++ b/src/pages/myTodo/components/todo/Todo.tsx
@@ -128,17 +128,6 @@ const Todo = () => {
     }
   };
 
-  const handleRefresh = () => {
-    setRefreshCounter((prev) => prev + 1);
-
-    if (selectedJobId) {
-      queryClient.invalidateQueries({ queryKey: ['todoGroup', selectedJobId] });
-      refetchTodoGroup();
-    } else {
-      queryClient.refetchQueries({ queryKey: ['mdTodo'], exact: true });
-    }
-  };
-
   if (isJobsLoading || (isTodoLoading && !todoData)) {
     return (
       <div className="py-4 text-gray-500 font-B01-M">
@@ -195,12 +184,6 @@ const Todo = () => {
           )}
         </div>
         <div className="flex items-center gap-2">
-          <button
-            onClick={handleRefresh}
-            className="mr-2 text-gray-500 font-B03-M hover:text-purple-500"
-          >
-            새로고침
-          </button>
           <div className="flex items-center gap-2 text-gray-500 font-B03-M">
             <Eye />
             조회수 {totalView}

--- a/src/pages/otherTodoList/OtherTodoListPage.tsx
+++ b/src/pages/otherTodoList/OtherTodoListPage.tsx
@@ -1,9 +1,9 @@
 import { useParams, useNavigate } from 'react-router-dom';
 import BackIcon from '@assets/icons/back.svg?react';
-import TodoCard from '@pages/otherTodoList/components/TodoCard.tsx';
 import { useEachTodosQuery } from '@hook/useJobQuery.ts';
 import BaseImg from '@assets/images/profile.png';
 import LoadingSpinner from '@common/LoadingSpinner';
+import OtherTodoCard from '@pages/otherTodoList/components/OtherTodoCard.tsx';
 
 const OtherTodoListPage = () => {
   const navigate = useNavigate();
@@ -55,17 +55,14 @@ const OtherTodoListPage = () => {
 
             <div className="mt-[50px] flex w-[1000px] flex-col gap-6">
               {Array.isArray(eachTodos?.todos) && (
-                <TodoCard
+                <OtherTodoCard
                   title="할 일 목록"
                   todos={eachTodos.todos.map((todo) => ({
                     todoId: todo.todoId,
                     title: todo.title,
                     completed: todo.completed,
-                    isMemoExist: todo.isMemoExist,
                     isPublic: todo.isPublic,
                   }))}
-                  showAddButton={false}
-                  disableHover={true}
                 />
               )}
             </div>

--- a/src/pages/otherTodoList/components/OtherTodoCard.tsx
+++ b/src/pages/otherTodoList/components/OtherTodoCard.tsx
@@ -1,0 +1,89 @@
+import CheckIcon from '@assets/icons/check.svg?react';
+import { useNavigate } from 'react-router-dom';
+import { useState, useEffect } from 'react';
+import LoadingSpinner from '@common/LoadingSpinner';
+import { useMemoQuery } from '@hook/mydream/useGetMemo';
+
+interface TodoItem {
+  todoId: number;
+  title: string;
+  completed: boolean;
+
+  isPublic: boolean;
+}
+
+interface TodoCardProps {
+  title?: string;
+  todos: TodoItem[];
+}
+
+const OtherTodoCard = ({ title, todos }: TodoCardProps) => {
+  const navigate = useNavigate();
+  const [isLoading, setIsLoading] = useState(false);
+  const [selectedTodoId, setSelectedTodoId] = useState<number | null>(null);
+
+  const {
+    data,
+    isLoading: isMemoLoading,
+    isError,
+  } = useMemoQuery(selectedTodoId || 0, {
+    enabled: !!selectedTodoId,
+    retry: false,
+  });
+
+  useEffect(() => {
+    if (data) {
+      setSelectedTodoId(null);
+      setIsLoading(false);
+    }
+
+    if (isError) {
+      console.error('메모를 불러오는 데 실패했습니다:', isError);
+      alert('메모를 불러오는 데 실패했습니다. 다시 시도해주세요.');
+      setSelectedTodoId(null);
+      setIsLoading(false);
+    }
+  }, [data, isError, selectedTodoId, navigate]);
+
+  return (
+    <div className="flex flex-col justify-between rounded-[30px] border border-gray-300 bg-white p-[30px]">
+      {(isLoading || isMemoLoading) && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-white/70">
+          <LoadingSpinner />
+        </div>
+      )}
+
+      <div className="mb-4 border-b border-gray-300 pb-4 text-black font-T05-SB">
+        {title}
+      </div>
+
+      <ul className="w-full flex-grow space-y-4">
+        {todos.map((item, index) => (
+          <li key={index} className={`flex items-center px-2 py-1`}>
+            <div
+              className={`flex h-[30px] w-[30px] cursor-pointer items-center justify-center rounded-[8px] border ${
+                item.completed
+                  ? 'border-gray-500 bg-gray-300'
+                  : 'border-gray-300 bg-gray-100'
+              }`}
+            >
+              {item.completed && <CheckIcon className="h-4 w-8 text-white" />}
+            </div>
+
+            <div className="flex flex-1 items-center gap-3 pl-3">
+              <span
+                className={`font-B01-M ${
+                  item.completed ? 'text-gray-500' : 'text-gray-900'
+                }`}
+              >
+                {item.title}
+              </span>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default OtherTodoCard;

--- a/src/pages/otherTodoList/components/OtherTodoCard.tsx
+++ b/src/pages/otherTodoList/components/OtherTodoCard.tsx
@@ -17,7 +17,7 @@ interface TodoCardProps {
   todos: TodoItem[];
 }
 
-const OtherTodoCard = ({ title, todos }: TodoCardProps) => {
+const OtherTodoCard = ({ todos }: TodoCardProps) => {
   const navigate = useNavigate();
   const [isLoading, setIsLoading] = useState(false);
   const [selectedTodoId, setSelectedTodoId] = useState<number | null>(null);
@@ -52,10 +52,6 @@ const OtherTodoCard = ({ title, todos }: TodoCardProps) => {
           <LoadingSpinner />
         </div>
       )}
-
-      <div className="mb-4 border-b border-gray-300 pb-4 text-black font-T05-SB">
-        {title}
-      </div>
 
       <ul className="w-full flex-grow space-y-4">
         {todos.map((item, index) => (


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안
- [x] 기능 추가  
- [x] 기능 삭제  
- [ ] 버그 수정  
- [x] 스타일링  


## ✈️ 관련 이슈
<!-- 닫고자 하는 이슈 번호를 아래에 적어주세요. 예: close #(이슈번호) -->
close #231 

## 📋 작업 내용
<!-- 수정한 내용이나 추가한 기능에 대해 자세히 설명해 주세요. -->
- 다른 드리머 상세페이지의 체크박스 색 변경 (OtherTodo.tsx)
- 다른 드리머의 상세페이지 레이아웃 수정
- 나의 할일의 메모 버튼 삭제
- 편집 시 useUpdateMemoMutation을 이용하여 타이틀 변경되도록 수정
- 나의 할일의 EmptyState.tsx 라이팅 수정

## 📸 스크린샷 (선택 사항)
<!-- 수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부할 수 있습니다. -->
<img width="1231" height="620" alt="image" src="https://github.com/user-attachments/assets/bf0a5a00-04c9-4d0c-bea2-0dd04815bb70" />
<img width="1390" height="857" alt="image" src="https://github.com/user-attachments/assets/edc86b42-527f-4eef-815d-f5ec8313b69d" />
<img width="1396" height="869" alt="image" src="https://github.com/user-attachments/assets/54cd4a53-48f0-4daa-83ef-14d1b2292a26" />


## 📄 기타
<!-- 추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 체크리스트 항목에 대한 인라인(즉시) 편집 기능이 추가되었습니다. 저장 및 취소 버튼을 통해 수정 내용을 관리할 수 있습니다.
  * 새로운 OtherTodoCard 컴포넌트가 도입되어, 다른 사용자의 할 일 목록을 별도로 표시합니다.

* **기능 개선**
  * EmptyTodo 화면의 문구와 버튼, 이미지 위치가 사용자에게 더 명확하게 안내하도록 개선되었습니다.
  * Todo 화면에서 새로고침 버튼이 제거되고, 빈 할 일 목록이 중앙에 보다 보기 좋게 표시됩니다.
  * OtherTodoListPage에서 할 일 목록 표시 방식이 OtherTodoCard 컴포넌트 기반으로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->