### PR TITLE
[✨FEATURE] 마이페이지 닉네임 중복확인 추가

### DIFF
--- a/src/pages/mypage/Mypage.tsx
+++ b/src/pages/mypage/Mypage.tsx
@@ -14,6 +14,7 @@ const Mypage = () => {
   const [quit, setIsQuit] = useState(false);
   const logout = useLogout();
   const navigate = useNavigate();
+  const [nicknameMessageVisible, setNicknameMessageVisible] = useState(false);
 
   const { data: InfoData } = useGetInfo();
 
@@ -22,10 +23,14 @@ const Mypage = () => {
       <div className="mb-[153px] mt-10 flex w-[796px] flex-col items-start">
         <div className="text-black font-T01-B">나의 계정</div>
 
-        <div className="mt-[60px] flex items-center space-x-11">
+        <div
+          className={`mt-[60px] flex items-center space-x-11 ${nicknameMessageVisible ? 'mb-10' : ''}`}
+        >
           <ProfileImageUploader imageUrl={InfoData?.profileImage} />
-
-          <Nickname nickname={InfoData?.nickname || ''} />
+          <Nickname
+            nickname={InfoData?.nickname || ''}
+            onMessageVisibleChange={setNicknameMessageVisible}
+          />
         </div>
 
         <div className="mt-10 flex w-full flex-col rounded-[20px] border border-gray-300 p-7">
@@ -42,7 +47,7 @@ const Mypage = () => {
             </div>
 
             <button
-              className="flex items-center rounded-[10px] bg-gray-900 px-[10px] py-2 text-white font-B03-M"
+              className="flex items-center rounded-[10px] bg-purple-500 px-[10px] py-2 text-white font-B03-M"
               onClick={() => setIsPasswordModal(true)}
             >
               변경
@@ -81,7 +86,7 @@ const Mypage = () => {
             </div>
 
             <button
-              className="flex items-center rounded-[10px] bg-gray-900 px-[10px] py-2 text-white font-B03-M"
+              className="flex items-center rounded-[10px] bg-purple-500 px-[10px] py-2 text-white font-B03-M"
               onClick={() => navigate('/jobselect')}
             >
               변경

--- a/src/pages/mypage/components/Nickname.tsx
+++ b/src/pages/mypage/components/Nickname.tsx
@@ -3,15 +3,21 @@ import Edit from '@assets/icons/edit-nickname.svg?react';
 import { useEditNicknameMutation } from '@hook/mypage/useEditNicknameMutation';
 import { useQueryClient } from '@tanstack/react-query';
 import { useUserStore } from '@store/useUserStore';
+import { useDuplicateNicknameMutation } from '@hook/useSignup';
 
 interface Props {
   nickname: string;
+  onMessageVisibleChange?: (visible: boolean) => void;
 }
 
-const Nickname = ({ nickname }: Props) => {
+const Nickname = ({ nickname, onMessageVisibleChange }: Props) => {
   const [tempNickname, setTempNickname] = useState(nickname);
   const [isEditing, setIsEditing] = useState(false);
+  const [isDuplicateCheckNeeded, setIsDuplicateCheckNeeded] = useState(false);
+  const [message, setMessage] = useState('');
+  const [messageType, setMessageType] = useState<'success' | 'error' | ''>('');
   const { mutate: editNickname } = useEditNicknameMutation();
+  const { mutate: checkNickname } = useDuplicateNicknameMutation();
   const queryClient = useQueryClient();
   const setNickname = useUserStore((state) => state.setNickname);
 
@@ -19,9 +25,46 @@ const Nickname = ({ nickname }: Props) => {
     setTempNickname(nickname);
   }, [nickname]);
 
+  useEffect(() => {
+    const changed = tempNickname !== nickname;
+    setIsDuplicateCheckNeeded(changed);
+    setMessage('');
+    setMessageType('');
+  }, [tempNickname, nickname]);
+
+  useEffect(() => {
+    onMessageVisibleChange?.(!!message);
+  }, [message, onMessageVisibleChange]);
+
+  const handleDuplicateCheck = () => {
+    if (!tempNickname.trim()) {
+      setMessage('닉네임을 입력해주세요.');
+      setMessageType('error');
+      return;
+    }
+
+    checkNickname(tempNickname, {
+      onSuccess: (res) => {
+        if (res.data.duplicated) {
+          setMessage('이미 있는 닉네임이에요');
+          setMessageType('error');
+        } else {
+          setMessage('사용할 수 있는 닉네임이에요');
+          setMessageType('success');
+          setIsDuplicateCheckNeeded(false);
+        }
+      },
+      onError: () => {
+        setMessage('이미 사용 중인 닉네임이에요');
+        setMessageType('error');
+      },
+    });
+  };
+
   const handleSave = () => {
     if (!tempNickname.trim()) {
-      alert('닉네임을 입력해주세요.');
+      setMessage('닉네임을 입력해주세요.');
+      setMessageType('error');
       return;
     }
 
@@ -39,24 +82,46 @@ const Nickname = ({ nickname }: Props) => {
 
   if (isEditing) {
     return (
-      <div className="flex items-center space-x-3">
-        <input
-          className="flex h-11 w-[166px] items-center rounded-[10px] border border-purple-500 bg-gray-100 px-5 py-[11px] text-gray-900 font-B01-M"
-          value={tempNickname}
-          onChange={(e) => setTempNickname(e.target.value)}
-        />
-        <button
-          className="flex items-center rounded-[10px] border border-gray-900 px-[10px] py-2 text-gray-900 font-B03-M"
-          onClick={() => setIsEditing(false)}
-        >
-          취소
-        </button>
-        <button
-          className="ml-1 flex items-center rounded-[10px] bg-gray-900 px-[10px] py-2 text-white font-B03-M"
-          onClick={handleSave}
-        >
-          저장
-        </button>
+      <div className="relative w-fit">
+        <div className="flex items-center space-x-3">
+          <input
+            className="flex h-11 w-[200px] items-center rounded-[10px] border border-purple-500 bg-gray-50 px-5 py-[11px] text-gray-900 font-B01-M focus:border-purple-500"
+            value={tempNickname}
+            placeholder="닉네임을 입력해주세요"
+            onChange={(e) => setTempNickname(e.target.value)}
+          />
+          <button
+            className="flex items-center rounded-[10px] border border-purple-500 px-[10px] py-2 text-purple-500 font-B03-M"
+            onClick={() => setIsEditing(false)}
+          >
+            취소
+          </button>
+          {isDuplicateCheckNeeded ? (
+            <button
+              className="ml-1 flex items-center rounded-[10px] bg-purple-500 px-[10px] py-2 text-white font-B03-M"
+              onClick={handleDuplicateCheck}
+            >
+              중복확인
+            </button>
+          ) : (
+            <button
+              className="ml-1 flex items-center rounded-[10px] bg-purple-500 px-[10px] py-2 text-white font-B03-M"
+              onClick={handleSave}
+            >
+              저장
+            </button>
+          )}
+        </div>
+
+        {message && (
+          <p
+            className={`absolute left-0 top-full mt-5 font-B02-M ${
+              messageType === 'success' ? 'text-success' : 'text-warning'
+            }`}
+          >
+            {message}
+          </p>
+        )}
       </div>
     );
   }

--- a/src/pages/mypage/components/UpdateRegion.tsx
+++ b/src/pages/mypage/components/UpdateRegion.tsx
@@ -47,7 +47,7 @@ const UpdateRegion = ({ regionName }: RegionCardProps) => {
         </div>
 
         <button
-          className="flex items-center rounded-[10px] bg-gray-900 px-[10px] py-2 text-white font-B03-M"
+          className="flex items-center rounded-[10px] bg-purple-500 px-[10px] py-2 text-white font-B03-M"
           onClick={() => setRegionModal(true)}
         >
           변경


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안
- [x] 기능 추가  
- [ ] 기능 삭제  
- [ ] 버그 수정  
- [ ] 스타일링  
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트  
- [ ] 기타  

## ✈️ 관련 이슈
<!-- 닫고자 하는 이슈 번호를 아래에 적어주세요. 예: close #(이슈번호) -->
close #261 

## 📋 작업 내용
<!-- 수정한 내용이나 추가한 기능에 대해 자세히 설명해 주세요. -->
- 마이페이지 닉네임 중복검사 추가 
- 버튼 색 변경

## 📸 스크린샷 (선택 사항)
<!-- 수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부할 수 있습니다. -->


## 📄 기타
<!-- 추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 닉네임 수정 시 중복 확인 기능이 추가되어, 닉네임 변경 시 중복 여부를 바로 확인할 수 있습니다.
  * 닉네임 입력란 아래에 성공/오류 메시지가 실시간으로 표시됩니다.

* **스타일**
  * 비밀번호 변경, 직업 선택, 지역 변경 버튼의 배경색이 보라색으로 변경되었습니다.
  * 닉네임 입력란의 UI가 개선되고, 버튼 스타일이 보라색 테마로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->