### PR TITLE
fix: [#330] 커뮤니티 왼쪽 사이드바에서 navigate 경로를 item.id에서 item.todoGroupId로 수정

### DIFF
--- a/src/pages/community/components/CommunityLeftSide.tsx
+++ b/src/pages/community/components/CommunityLeftSide.tsx
@@ -47,7 +47,7 @@ const CommunityLeftSide = () => {
             <div
               key={item.id}
               className="flex w-full cursor-pointer flex-row items-start justify-between py-4"
-              onClick={() => navigate(`/otherslist/${item.id}`)}
+              onClick={() => navigate(`/otherslist/${item.todoGroupId}`)}
             >
               <div className="flex flex-row items-center gap-[15px]">
                 <div className="text-purple-500 font-T05-SB">{idx + 1}</div>


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안
- [ ] 기능 추가  
- [ ] 기능 삭제  
- [ ] 버그 수정  
- [ ] 스타일링  
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트  
- [ ] 기타  

## ✈️ 관련 이슈
<!-- 닫고자 하는 이슈 번호를 아래에 적어주세요. 예: close #(이슈번호) -->


## 📋 작업 내용
<!-- 수정한 내용이나 추가한 기능에 대해 자세히 설명해 주세요. -->


## 📸 스크린샷 (선택 사항)
<!-- 수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부할 수 있습니다. -->


## 📄 기타
<!-- 추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 커뮤니티의 HOT 할 일 목록에서 항목 클릭 시 잘못된 상세 페이지로 이동하던 문제를 해결했습니다. 이제 해당 항목의 그룹 상세 화면으로 정확히 이동합니다.
  * 링크 식별자가 일관되게 적용되어 잘못된 링크 공유나 오탐색을 방지합니다.
  * 화면 표시나 목록 렌더링 방식은 기존과 동일하며, 탐색 흐름의 정확성과 신뢰성이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->